### PR TITLE
aup: reword for clarity

### DIFF
--- a/Acceptable Usage Policy.md
+++ b/Acceptable Usage Policy.md
@@ -18,7 +18,7 @@ Online communities have the potential to change people's lives, so we want to en
 
 Engaging in any of the following actions will result in a warning and may lead to having your account suspended.
 
-- Creating accounts soley to or using your account to send unsolicited advertisements to other people on the platform or to harass other individuals on the platform.
+- Creating accounts or using existing accounts to send unsolicited advertisements to other people on the platform or to harass other individuals on the platform.
 - Sharing any kind of copyrighted content, or any type of content that violates another person's personal, intellectual property or other rights. This includes any content that would violate the Digital Millennium Copyright Act (DMCA). We respond to DMCA requests as described in our [Terms of Service](https://revolt.chat/terms).
 - Using Revolt for illegal operations. These include, but are not limited to, hacking, the cracking or distribution of pirated software, cheats, exploits or hacks for our or another company or person's service.
 - Using Revolt with malicious intent, in a way that is not reasonable under normal usage, in order to outsource computing and/or storage resources to our servers, as well as other forms of Denial of Service to our infrastructure.
@@ -38,7 +38,7 @@ Engaging in any of the following will result in an **immediate account terminati
 - Attempts to hack or otherwise gain unauthorised access to our service - for example, accessing another person's account without permission, or attempting to steal another person's account. This also includes attempts to gain access to our backend networks.
 **Please contact us ahead of time for permission to test our networks by emailing [security@revolt.chat](mailto:security@revolt.chat).**
 - Distributing malware such as viruses, trojans, worms, etc. Any software designed with malicious intent to attack another person or to steal their data is not tolerated.
-- Sharing content that is designed to harass or degrade another person, or that can directly threaten someone's physical, mental or financial state. This includes death threats, doxxing (sharing personal information without permission), or ignoring a person's privacy.
+- Sharing content that is designed to harass or degrade someone else, or that can directly threaten someone's physical, mental or financial state. This includes death threats, doxxing (sharing personal information without permission), or ignoring someone's privacy.
 
 To report any of the above activity, contact us at [abuse@revolt.chat](mailto:abuse@revolt.chat).
 

--- a/Acceptable Usage Policy.md
+++ b/Acceptable Usage Policy.md
@@ -1,49 +1,49 @@
-*Last updated: 13. November 2021*
+*Last updated: 21st February 2022*
 
 # Acceptable Usage Policy
 
-This **AUP** applies to the official instance of REVOLT available at [revolt.chat](http://revolt.chat), self-hosted instances may choose to adopt this AUP if they wish.
+This **Acceptable Usage Policy** (**AUP**) applies to the official instance of Revolt available at [revolt.chat](http://revolt.chat). Self-hosted instances may choose to adopt this AUP if they wish. 
 
 ## Community Guidelines
 
-**REVOLT** can cater to your community, raid guild, study group and anything in-between. We encourage you to:
+**Revolt** can cater to your community, raid guild, study group and anything in-between. We encourage you to:
 
 - Take advantage of our powerful community tools.
 - Be kind and make friends with others on our platform.
 - Have fun talking and sharing content on our platform.
 
-Online communities have the potential to change people's lives, we want to encourage a positive environment for anyone willing to join.
+Online communities have the potential to change people's lives, so we want to encourage a positive environment for anyone willing to join.
 
 ### What We Don't Allow
 
 Engaging in any of the following actions will result in a warning and may lead to having your account suspended.
 
-- Creating accounts to or using your account to send unsolicited advertisements to other people on the platform or to harass other individuals on the platform.
+- Creating accounts soley to or using your account to send unsolicited advertisements to other people on the platform or to harass other individuals on the platform.
 - Sharing any kind of copyrighted content, or any type of content that violates another person's personal, intellectual property or other rights. This includes any content that would violate the Digital Millennium Copyright Act (DMCA). We respond to DMCA requests as described in our [Terms of Service](https://revolt.chat/terms).
-- Using REVOLT for illegal operation, such as, but not limited to, hacking, cracking or distribution of pirated software, cheats, exploits or hacks for our or another company or person's service.
-- Using REVOLT with malicious intent, in a way that is not reasonable under normal usage, in order to outsource computing and/or storage resources to our servers, as well as other forms of Denial of Service to our infrastructure.
-- Sharing any type of imagery that depicts real-life violence, gore or animal cruelty. Nobody wants to see this and neither should you. Exception is violence portrayed in media such as movies, games, books, and so forth.
-- The selling and buying of user accounts is prohibited.
+- Using Revolt for illegal operations. These include, but are not limited to, hacking, the cracking or distribution of pirated software, cheats, exploits or hacks for our or another company or person's service.
+- Using Revolt with malicious intent, in a way that is not reasonable under normal usage, in order to outsource computing and/or storage resources to our servers, as well as other forms of Denial of Service to our infrastructure.
+- Sharing any type of imagery that depicts real-life violence, gore or animal cruelty. Nobody wants to see this and neither should you. However, an exception to this rule has been made for violence portrayed in media (including movies, games, books and such).
+- The selling and buying of Revolt accounts is prohibited.
 
 To report any of the above activity, contact us at [abuse@revolt.chat](mailto:abuse@revolt.chat).
 
-Please note we are *committed to resolving every single report*, please be patient and **do not spam our support team**, we appreciate your concerns and will act upon them.
+Please note we are *committed to resolving every single report*. Please be patient and **do not spam our support team** - we appreciate your concerns and will act upon them.
 
 ### What We Can't Allow
 
-Engaging in any of the following will result in **immediate account termination** as well as content removal. You may also be **blacklisted** from using our services indefinitely.
+Engaging in any of the following will result in an **immediate account termination** as well as the removal of any infringing content. You may also be **indefinitely prohibited** from using our services.
 
-- Sharing any content or imagery illegal within the European Union, we don't want you or us to get into any legal trouble, stay in line by not engaging in illegal activity content such as, but not limited to, sharing any pornography that is subject to legal age restrictions, depicting minors, sharing revenge pornography, selling or facilitating the usage of drugs, extortion or blackmail.
-- Sharing any content promoting, encouraging or glorifying self-harm or suicide. This includes any content that pushes people to: cut or injure themselves; embrace eating disorders such as anorexia or bulimia; or commit suicide as opposed to referring people to the correct treatment and help. If you notice someone in need of urgent help, contact your local authorities.
-- Attempts to hack or otherwise gain unauthorised access to our service. For example, accessing another person's account without permission, or attempting to steal another person's account. This also includes attempts in order to gain access to our back end networks.
-**Please contact us ahead of time for permission to test our networks, [security@revolt.chat](mailto:security@revolt.chat).**
+- Sharing any content or imagery that is illegal within the European Union. We don't want you or us to get into any legal trouble, so stay in line by not engaging in illegal activities or sharing illegal content such as, but not limited to, sharing any pornography that is subject to legal age restrictions, pornography that depicts minors, revenge pornography, the selling or facilitating the usage of drugs, extortion or blackmail.
+- Sharing any content promoting, encouraging or glorifying self-harm or suicide. This includes any content that pushes people to cut or injure themselves; that embraces eating disorders such as anorexia or bulimia; or that encourages people to commit suicide as opposed to referring them to the correct treatment and help. If you notice someone in need of urgent help, **please contact your local authorities**.
+- Attempts to hack or otherwise gain unauthorised access to our service - for example, accessing another person's account without permission, or attempting to steal another person's account. This also includes attempts to gain access to our backend networks.
+**Please contact us ahead of time for permission to test our networks by emailing [security@revolt.chat](mailto:security@revolt.chat).**
 - Distributing malware such as viruses, trojans, worms, etc. Any software designed with malicious intent to attack another person or to steal their data is not tolerated.
-- Sharing content that is designed to harass or degrade another person, any content that can directly threaten someone's physical, mental or financial state, this includes death threats, doxxing (sharing personal information), or ignoring one's privacy.
+- Sharing content that is designed to harass or degrade another person, or that can directly threaten someone's physical, mental or financial state. This includes death threats, doxxing (sharing personal information without permission), or ignoring a person's privacy.
 
 To report any of the above activity, contact us at [abuse@revolt.chat](mailto:abuse@revolt.chat).
 
 ### Strikes
 
-Strikes are **irreversible**, but account suspensions can be removed through appeal, but only if you believe that we took the wrong action. There is no point asking to be appealed for breaking the law.
+Strikes are **irreversible**. Account suspensions can be removed through a successful appeal, but only if you believe that we took the wrong action. There is no point asking to be appealed for breaking the law.
 
-If you would like to appeal, please contact [abuse@revolt.chat](mailto:abuse@revolt.chat).
+If you would like to appeal a suspension, please contact [abuse@revolt.chat](mailto:abuse@revolt.chat).


### PR DESCRIPTION
This PR consists of wording/grammatical changes made for clarity. There should be no changes in terms of the meaning of any of the AUP's rules.